### PR TITLE
Enable topic filter on dataset search endpoint 

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 
+	"github.com/ONSdigital/dp-census-dataset-search-api/models"
 	"github.com/ONSdigital/go-ns/server"
 	"github.com/ONSdigital/log.go/log"
 	"github.com/gorilla/mux"
@@ -16,10 +17,11 @@ type SearchAPI struct {
 	elasticsearch     Elasticsearcher
 	router            *mux.Router
 	datasetIndex      string
+	taxonomy          models.Taxonomy
 }
 
 // CreateAndInitialiseSearchAPI manages all the routes configured to API
-func CreateAndInitialiseSearchAPI(ctx context.Context, bindAddr string, esAPI Elasticsearcher, defaultMaxResults int, datasetIndex string, errorChan chan error) {
+func CreateAndInitialiseSearchAPI(ctx context.Context, bindAddr string, esAPI Elasticsearcher, defaultMaxResults int, datasetIndex string, taxonomy models.Taxonomy, errorChan chan error) {
 
 	router := mux.NewRouter()
 	routes(ctx,
@@ -27,6 +29,7 @@ func CreateAndInitialiseSearchAPI(ctx context.Context, bindAddr string, esAPI El
 		esAPI,
 		defaultMaxResults,
 		datasetIndex,
+		taxonomy,
 	)
 
 	httpServer = server.New(bindAddr, router)
@@ -47,16 +50,20 @@ func routes(ctx context.Context,
 	router *mux.Router,
 	elasticsearch Elasticsearcher,
 	defaultMaxResults int,
-	datasetIndex string) *SearchAPI {
+	datasetIndex string,
+	taxonomy models.Taxonomy) *SearchAPI {
 
 	api := SearchAPI{
 		defaultMaxResults: defaultMaxResults,
 		elasticsearch:     elasticsearch,
 		router:            router,
 		datasetIndex:      datasetIndex,
+		taxonomy:          taxonomy,
 	}
 
 	api.router.HandleFunc("/datasets", api.getDatasets).Methods("GET", "OPTIONS")
+	api.router.HandleFunc("/taxonomy", api.getTaxonomy).Methods("GET", "OPTIONS")
+	api.router.HandleFunc("/taxonomy/{topic}", api.getTopic).Methods("GET", "OPTIONS")
 
 	return &api
 }

--- a/api/taxonomy.go
+++ b/api/taxonomy.go
@@ -1,0 +1,131 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+
+	errs "github.com/ONSdigital/dp-census-dataset-search-api/apierrors"
+	"github.com/ONSdigital/dp-census-dataset-search-api/models"
+	"github.com/ONSdigital/log.go/log"
+	"github.com/gorilla/mux"
+)
+
+func (api *SearchAPI) getTaxonomy(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	setAccessControl(w, http.MethodGet)
+
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	log.Event(ctx, "getTaxonomy endpoint: incoming request", log.INFO)
+
+	b, err := json.Marshal(api.taxonomy)
+	if err != nil {
+		log.Event(ctx, "getTaxonomy endpoint: failed to marshal search resource into bytes", log.ERROR, log.Error(err))
+		setErrorCode(w, errs.ErrInternalServer)
+	}
+
+	_, err = w.Write(b)
+	if err != nil {
+		log.Event(ctx, "getTaxonomy endpoint: error writing response", log.ERROR, log.Error(err))
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	log.Event(ctx, "getTaxonomy endpoint: successfully searched index", log.INFO)
+}
+
+// Topic ...
+type Topic struct {
+	ParentTopic string   `json:"parent_topic,omitempty"`
+	Title       string   `json:"title"`
+	Topic       string   `json:"topic"`
+	ChildTopics []string `json:"child_topics,omitempty"`
+}
+
+func (api *SearchAPI) getTopic(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	setAccessControl(w, http.MethodGet)
+
+	if r.Method == http.MethodOptions {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+
+	vars := mux.Vars(r)
+	topic := vars["topic"]
+	logData := log.Data{"topic": topic}
+
+	log.Event(ctx, "getTopic endpoint: incoming request", log.INFO, logData)
+
+	var result *Topic
+	var hasValidTopic bool
+	for _, taxonomy := range api.taxonomy.Topics {
+		if topic == taxonomy.FormattedTitle {
+			hasValidTopic = true
+
+			var childTopics []string
+			for _, childTopic := range taxonomy.ChildTopics {
+				childTopics = append(childTopics, childTopic.FormattedTitle)
+			}
+
+			result = &Topic{
+				Title:       taxonomy.Title,
+				Topic:       topic,
+				ChildTopics: childTopics,
+			}
+
+			break
+		}
+
+		result, hasValidTopic = checkChildTopics(taxonomy, topic)
+		if hasValidTopic {
+			break
+		}
+	}
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		log.Event(ctx, "getTopic endpoint: failed to marshal search resource into bytes", log.ERROR, log.Error(err), logData)
+		setErrorCode(w, errs.ErrInternalServer)
+	}
+
+	_, err = w.Write(b)
+	if err != nil {
+		log.Event(ctx, "getTopic endpoint: error writing response", log.ERROR, log.Error(err), logData)
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+	}
+
+	log.Event(ctx, "getTopic endpoint: successfully searched index", log.INFO, logData)
+}
+
+func checkChildTopics(taxonomy models.Topic, topic string) (result *Topic, hasValidTopic bool) {
+
+	for _, childTopic := range taxonomy.ChildTopics {
+		if topic == childTopic.FormattedTitle {
+			hasValidTopic = true
+
+			var childTopics []string
+			for _, childTopic := range childTopic.ChildTopics {
+				childTopics = append(childTopics, childTopic.FormattedTitle)
+			}
+
+			result = &Topic{
+				ParentTopic: taxonomy.FormattedTitle,
+				Title:       childTopic.Title,
+				Topic:       topic,
+				ChildTopics: childTopics,
+			}
+
+			break
+		}
+
+		result, hasValidTopic = checkChildTopics(childTopic, topic)
+		if hasValidTopic {
+			break
+		}
+	}
+
+	return
+}

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -9,6 +9,7 @@ var (
 	ErrInternalServer         = errors.New("internal server error")
 	ErrMarshallingQuery       = errors.New("failed to marshal query to bytes for request body to send to elastic")
 	ErrParsingQueryParameters = errors.New("failed to parse query parameters, values must be an integer")
+	ErrTooManyTopicFilters    = errors.New("Too many topic filters, limited to a maximum of 10")
 	ErrUnmarshallingJSON      = errors.New("failed to parse json body")
 	ErrUnexpectedStatusCode   = errors.New("unexpected status code from elastic api")
 
@@ -17,5 +18,6 @@ var (
 	BadRequestMap = map[error]bool{
 		ErrEmptySearchTerm:        true,
 		ErrParsingQueryParameters: true,
+		ErrTooManyTopicFilters:    true,
 	}
 )

--- a/config/config.go
+++ b/config/config.go
@@ -11,6 +11,7 @@ type Config struct {
 	ElasticSearchAPIURL       string `envconfig:"ELASTIC_SEARCH_URL"         json:"-"`
 	MaxSearchResultsOffset    int    `envconfig:"MAX_SEARCH_RESULTS_OFFSET"`
 	SignElasticsearchRequests bool   `envconfig:"SIGN_ELASTICSEARCH_REQUESTS"`
+	TaxonomyFilename          string `envconfig:"TAXONOMY_FILENAME"`
 }
 
 var cfg *Config
@@ -27,6 +28,7 @@ func Get() (*Config, error) {
 		ElasticSearchAPIURL:       "http://localhost:9200",
 		MaxSearchResultsOffset:    1000,
 		SignElasticsearchRequests: false,
+		TaxonomyFilename:          "taxonomy/taxonomy.json",
 	}
 
 	return cfg, envconfig.Process("", cfg)

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,9 @@ require (
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gorilla/mux v1.7.4
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
-	github.com/smartystreets/assertions v1.0.1 // indirect
+	github.com/smartystreets/assertions v1.1.1 // indirect
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e h1:0aewS5NTyxftZHSnFaJmWE5oCCrj4DyEXkAiMa1iZJM=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=
@@ -53,6 +55,8 @@ github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykE
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/assertions v1.0.1 h1:voD4ITNjPL5jjBfgR/r8fPIIBrliWrWHeiJApdr3r4w=
 github.com/smartystreets/assertions v1.0.1/go.mod h1:kHHU4qYBaI3q23Pp3VPrmWhuIUrLW/7eUrw0BU5VaoM=
+github.com/smartystreets/assertions v1.1.1 h1:T/YLemO5Yp7KPzS+lVtu+WsHn8yoSwTfItdAd1r3cck=
+github.com/smartystreets/assertions v1.1.1/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
 github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/unrolled/render v1.0.2/go.mod h1:gN9T0NhL4Bfbwu8ann7Ry/TGHYfosul+J0obPf6NBdM=

--- a/models/filters.go
+++ b/models/filters.go
@@ -1,0 +1,158 @@
+package models
+
+import (
+	"errors"
+	"strings"
+
+	errs "github.com/ONSdigital/dp-census-dataset-search-api/apierrors"
+)
+
+const maximumTopicFilters = 10
+
+// ErrorInvalidTopics - return error
+func ErrorInvalidTopics(topicList []string) error {
+	topics := strings.Join(topicList, ",")
+	err := errors.New("invalid list of topics to filter by: " + topics)
+	return err
+}
+
+// ValidateTopics checks the values in topics are valid
+func ValidateTopics(topics string) ([]Filter, error) {
+	if topics == "" {
+		return nil, nil
+	}
+
+	topicList := strings.Split(topics, ",")
+
+	if len(topicList) > maximumTopicFilters {
+		return nil, errs.ErrTooManyTopicFilters
+	}
+
+	var invalidTopics, topic1List, topic2List, topic3List []string
+	for _, topic := range topicList {
+		if validTopics[topic] < 1 {
+			invalidTopics = append(invalidTopics, topic)
+		} else if validTopics[topic] == 1 {
+			topic1List = append(topic1List, topic)
+		} else if validTopics[topic] == 2 {
+			topic2List = append(topic2List, topic)
+		} else if validTopics[topic] == 3 {
+			topic3List = append(topic3List, topic)
+		}
+	}
+
+	if len(invalidTopics) > 0 {
+		return nil, ErrorInvalidTopics(invalidTopics)
+	}
+
+	var filters []Filter
+	if len(topic1List) > 0 {
+		filters = append(filters, Filter{
+			Terms: map[string][]string{"topic1": topic1List},
+		})
+	}
+
+	if len(topic2List) > 0 {
+		filters = append(filters, Filter{
+			Terms: map[string][]string{"topic2": topic2List},
+		})
+	}
+
+	if len(topic3List) > 0 {
+		filters = append(filters, Filter{
+			Terms: map[string][]string{"topic3": topic3List},
+		})
+	}
+
+	return filters, nil
+}
+
+var validTopics = map[string]int{
+	"adoption":                                 3,
+	"ageing":                                   3,
+	"balanceofpayments":                        3,
+	"birthsdeathsandmarriages":                 2,
+	"causesofdeath":                            3,
+	"childhealth":                              3,
+	"conceptionandfertilityrates":              3,
+	"conditionsanddiseases":                    3,
+	"crimeandjustice":                          2,
+	"culturalidentity":                         2,
+	"deaths":                                   3,
+	"debt":                                     3,
+	"disability":                               3,
+	"divorce":                                  3,
+	"drugusealcoholandsmoking":                 3,
+	"earningsandworkinghours":                  3,
+	"economicinactivity":                       3,
+	"economicoutputandproductivity":            2,
+	"economy":                                  1,
+	"educationandchildcare":                    2,
+	"elections":                                2,
+	"electoralregistration":                    3,
+	"employmentandemployeetypes":               3,
+	"employmentandlabourmarket":                1,
+	"environmentalaccounts":                    2,
+	"ethnicity":                                3,
+	"expenditure":                              3,
+	"families":                                 3,
+	"generalelections":                         3,
+	"governmentpublicsectorandtaxes":           2,
+	"grossdisposablehouseholdincome":           3,
+	"grossdomesticproductgdp":                  2,
+	"grossvalueaddedgva":                       2,
+	"healthandlifeexpectancies":                3,
+	"healthandsocialcare":                      2,
+	"healthandwellbeing":                       3,
+	"healthcaresystem":                         3,
+	"healthinequalities":                       3,
+	"homeinternetandsocialmediausage":          3,
+	"householdcharacteristics":                 2,
+	"housing":                                  2,
+	"incomeandwealth":                          3,
+	"inflationandpriceindices":                 2,
+	"internationalmigration":                   3,
+	"investmentspensionsandtrusts":             2,
+	"labourproductivity":                       3,
+	"language":                                 3,
+	"leisureandtourism":                        2,
+	"lifeexpectancies":                         3,
+	"livebirths":                               3,
+	"localgovernmentelections":                 3,
+	"localgovernmentfinance":                   3,
+	"marriagecohabitationandcivilpartnerships": 3,
+	"maternities":                              3,
+	"mentalhealth":                             3,
+	"migrationwithintheuk":                     3,
+	"nationalaccounts":                         2,
+	"outofworkbenefits":                        3,
+	"output":                                   3,
+	"pensionssavingsandinvestments":            3,
+	"peopleinwork":                             2,
+	"peoplenotinwork":                          2,
+	"peoplepopulationandcommunity":             1,
+	"personalandhouseholdfinances":             2,
+	"populationandmigration":                   2,
+	"populationestimates":                      3,
+	"populationprojections":                    3,
+	"productivitymeasures":                     3,
+	"publicsectorfinance":                      3,
+	"publicsectorpersonnel":                    3,
+	"publicservicesproductivity":               3,
+	"publicspending":                           3,
+	"redundancies":                             3,
+	"regionalaccounts":                         2,
+	"religion":                                 3,
+	"researchanddevelopmentexpenditure":        3,
+	"satelliteaccounts":                        3,
+	"sexuality":                                3,
+	"socialcare":                               3,
+	"stillbirths":                              3,
+	"supplyandusetables":                       3,
+	"taxesandrevenue":                          3,
+	"uksectoraccounts":                         3,
+	"unemployment":                             3,
+	"wellbeing":                                2,
+	"workplacedisputesandworkingconditions":    3,
+	"workplacepensions":                        3,
+}

--- a/models/query.go
+++ b/models/query.go
@@ -1,0 +1,56 @@
+package models
+
+// Body represents the request body to elasticsearch
+type Body struct {
+	From      int        `json:"from"`
+	Size      int        `json:"size"`
+	Highlight *Highlight `json:"highlight,omitempty"`
+	Query     Query      `json:"query"`
+	Sort      []Scores   `json:"sort"`
+	TotalHits bool       `json:"track_total_hits"`
+}
+
+// Highlight represents parts of the fields that matched
+type Highlight struct {
+	PreTags  []string          `json:"pre_tags,omitempty"`
+	PostTags []string          `json:"post_tags,omitempty"`
+	Fields   map[string]Object `json:"fields,omitempty"`
+	Order    string            `json:"score,omitempty"`
+}
+
+// Object represents an empty object (as expected by elasticsearch)
+type Object struct{}
+
+// Query represents the request query details
+type Query struct {
+	Bool Bool `json:"bool"`
+}
+
+// Bool represents the desirable goals for query
+type Bool struct {
+	Filter []Filter `json:"filter,omitempty"`
+	Must   []Match  `json:"must,omitempty"`
+	Should []Match  `json:"should,omitempty"`
+}
+
+// Filter represents the filtering object (can only contain eiter term or terms but not both)
+type Filter struct {
+	Term  map[string]string   `json:"term,omitempty"`
+	Terms map[string][]string `json:"terms,omitempty"`
+}
+
+// Match represents the fields that the term should or must match within query
+type Match struct {
+	Match map[string]string `json:"match,omitempty"`
+}
+
+// Scores represents a list of scoring, e.g. scoring on relevance, but can add in secondary
+// score such as alphabetical order if relevance is the same for two search results
+type Scores struct {
+	Score Score `json:"_score"`
+}
+
+// Score contains the ordering of the score (ascending or descending)
+type Score struct {
+	Order string `json:"order"`
+}

--- a/models/taxonomy.go
+++ b/models/taxonomy.go
@@ -1,0 +1,13 @@
+package models
+
+// Taxonomy represents the hierarchy of topics
+type Taxonomy struct {
+	Topics []Topic `json:"topics"`
+}
+
+// Topic represents the topic data and relates to child topics
+type Topic struct {
+	Title          string  `json:"title"`
+	FormattedTitle string  `json:"filterable_title"`
+	ChildTopics    []Topic `json:"child_topics,omitempty"`
+}

--- a/scripts/retrieve-dataset-taxonomy/main.go
+++ b/scripts/retrieve-dataset-taxonomy/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ONSdigital/dp-census-dataset-search-api/models"
 	"github.com/ONSdigital/log.go/log"
 )
 
@@ -25,16 +26,6 @@ var (
 
 	defaultFilename = "../taxonomy/taxonomy.json"
 )
-
-type Taxonomy struct {
-	Topics []Topic `json:"topics"`
-}
-
-type Topic struct {
-	Title          string  `json:"title"`
-	FormattedTitle string  `json:"formatted_title"`
-	ChildTopics    []Topic `json:"child_topics,omitempty"`
-}
 
 var topicList = make(map[string]int)
 
@@ -70,7 +61,7 @@ func main() {
 	}
 }
 
-func callONSWebite(ctx context.Context, url string) (*Taxonomy, error) {
+func callONSWebite(ctx context.Context, url string) (*models.Taxonomy, error) {
 
 	logData := log.Data{"url": url}
 
@@ -86,7 +77,7 @@ func callONSWebite(ctx context.Context, url string) (*Taxonomy, error) {
 		return nil, err
 	}
 
-	var topics []Topic
+	var topics []models.Topic
 	for _, section := range topTaxonomy.Sections {
 
 		topic, err := GetTopics(ctx, url, section.Theme.URI, 1)
@@ -100,7 +91,7 @@ func callONSWebite(ctx context.Context, url string) (*Taxonomy, error) {
 		topics = append(topics, *topic)
 	}
 
-	taxonomy := Taxonomy{
+	taxonomy := models.Taxonomy{
 		Topics: topics,
 	}
 
@@ -154,7 +145,7 @@ type ChildSection struct {
 	URI string `json:"uri`
 }
 
-func GetTopics(ctx context.Context, url, parentTopic string, level int) (*Topic, error) {
+func GetTopics(ctx context.Context, url, parentTopic string, level int) (*models.Topic, error) {
 	extendedURL := onsWebsite + parentTopic + "/data"
 	logData := log.Data{"url": extendedURL}
 
@@ -183,7 +174,7 @@ func GetTopics(ctx context.Context, url, parentTopic string, level int) (*Topic,
 		return nil, errors.New("failed to parse json body")
 	}
 
-	var topics []Topic
+	var topics []models.Topic
 	if childTaxonomy.Type == taxonomyLandingPage {
 		for _, section := range childTaxonomy.Sections {
 			topic, err := GetTopics(ctx, extendedURL, section.URI, level+1)
@@ -203,7 +194,7 @@ func GetTopics(ctx context.Context, url, parentTopic string, level int) (*Topic,
 	title := strings.SplitAfter(parentTopic, "/")
 	formattedTitle := title[len(title)-1]
 
-	topic := Topic{
+	topic := models.Topic{
 		Title:          childTaxonomy.Description.Title,
 		FormattedTitle: formattedTitle,
 		ChildTopics:    topics,

--- a/scripts/upload-datasets/main.go
+++ b/scripts/upload-datasets/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 
 	es "github.com/ONSdigital/dp-census-dataset-search-api/internal/elasticsearch"
+	"github.com/ONSdigital/dp-census-dataset-search-api/models"
 	dphttp "github.com/ONSdigital/dp-net/http"
 	"github.com/ONSdigital/log.go/log"
 )
@@ -26,7 +27,7 @@ const (
 
 var (
 	datasetIndex, elasticsearchAPIURL, filename, taxonomyFilename string
-	taxonomy                                                      Taxonomy
+	taxonomy                                                      models.Taxonomy
 	topicLevels                                                   = make(map[string]TopicLevels)
 )
 
@@ -41,17 +42,7 @@ type Dataset struct {
 	Topic3      string `json:"topic3,omitempty"`
 }
 
-// Taxonomy ...
-type Taxonomy struct {
-	Topics []Topic `json:"topics"`
-}
-
-type Topic struct {
-	Title          string  `json:"title"`
-	FormattedTitle string  `json:"formatted_title"`
-	ChildTopics    []Topic `json:"child_topics,omitempty"`
-}
-
+// TopicLevels represent the levels within the topic hierarchy (aka taxonomy)
 type TopicLevels struct {
 	TopicLevel1 string
 	TopicLevel2 string

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -57,6 +57,88 @@ paths:
               example: 86400
         500:
           $ref: '#/components/responses/InternalError'
+  /taxonomy:
+    get:
+      tags:
+      - "Public"
+      summary: "Returns a nested hierarchy of topics known as taxonomy"
+      responses:
+        200:
+          description: "A json list o topics broken down into 3 levels of hierarchy."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Taxonomy'
+        500:
+          $ref: '#/components/responses/InternalError'
+    options:
+      tags:
+      - "Public"
+      summary: "Information about the communication options available for the target resource"
+      responses:
+        204:
+          description: "No Content"
+          headers:
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              description: "The methods allowed access against this resource as a comma separated list."
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              description: "The web urls allowed access against this resource as a comma separated list."
+              example: "*"
+            Access-Control-Max-Age:
+              schema:
+                type: integer
+              description: "Header indicates how long the results of a preflight request can be cached."
+              example: 86400
+        500:
+          $ref: '#/components/responses/InternalError'
+  /taxonomy/{topic}:
+    get:
+      tags:
+      - "Public"
+      summary: "Returns a single topic resource with data on related parent and child topic resources within the taxonomy."
+      parameters:
+      - $ref: '#/components/parameters/topic'
+      responses:
+        200:
+          description: "A json list o topics broken down into 3 levels of hierarchy."
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Topic'
+        400:
+          $ref: '#/components/responses/InvalidRequestError'
+        500:
+          $ref: '#/components/responses/InternalError'
+    options:
+      tags:
+      - "Public"
+      summary: "Information about the communication options available for the target resource"
+      parameters:
+      - $ref: '#/components/parameters/topic'
+      responses:
+        204:
+          description: "No Content"
+          headers:
+            Access-Control-Allow-Methods:
+              schema:
+                type: string
+              description: "The methods allowed access against this resource as a comma separated list."
+            Access-Control-Allow-Origin:
+              schema:
+                type: string
+              description: "The web urls allowed access against this resource as a comma separated list."
+              example: "*"
+            Access-Control-Max-Age:
+              schema:
+                type: integer
+              description: "Header indicates how long the results of a preflight request can be cached."
+              example: 86400
+        500:
+          $ref: '#/components/responses/InternalError'
 components:
   parameters:
     q:
@@ -87,6 +169,13 @@ components:
       name: topics
       description: "A comma separated list of a maximum of 10 separate topics to filter the dataset search API against topic fields, topic1, topic2 and topic3. Filtering across the levels is not recommended and will likely result in there being no results being returned."
       in: query
+      schema:
+        type: string
+    topic:
+      name: topic
+      description: "A single topic name"
+      required: true
+      in: path
       schema:
         type: string
   schemas:
@@ -164,6 +253,76 @@ components:
         topic3:
           description: "Highlighted level 3 topic field due to query term matching keyword."
           type: string
+    Taxonomy:
+      type: object
+      properties:
+        topics:
+          description: ""
+          type: array
+          items:
+            $ref: '#/components/schemas/Topics'
+    Topics:
+      type: object
+      required: [
+        title,
+        filterable_title
+      ]
+      properties:
+        title:
+          description: "A human friendly title of a topic at the highest level of the taxonomy, level 1."
+          type: string
+        filterable_title:
+          description: "A separate formatted title that has removed all whitespace and grammar to allow better filtering and searching against a topic title."
+          type: string
+        child_topics:
+          description: "A list of level 2 topics that are related to this topic in the taxonomy hierarchy."
+          type: array
+          items:
+            $ref: '#/components/schemas/ChildTopics'
+    ChildTopics:
+      type: object
+      properties:
+        title:
+          description: "A human friendly title of a topic at the highest level of the taxonomy, level 2."
+          type: string
+        filterable_title:
+          description: "A separate formatted title that has removed all whitespace and grammar to allow better filtering and searching against a topic title."
+          type: string
+        child_topics:
+          description: "A list of level 3 topics that are related to this topic in the taxonomy hierarchy."
+          type: array
+          items:
+            $ref: '#/components/schemas/GrandchildTopics'
+    GrandchildTopics:
+      type: object
+      properties:
+        title:
+          description: "A human friendly title of a topic at the highest level of the taxonomy, level 3."
+          type: string
+        filterable_title:
+          description: "A separate formatted title that has removed all whitespace and grammar to allow better filtering and searching against a topic title."
+          type: string
+    Topic:
+      type: object
+      required: [
+        title,
+        topic
+      ]
+      properties:
+        parent_topic:
+          description: "The parent topic of this topic resource that the topic relates to in the taxonomy."
+          type: string
+        title:
+          description: "A human friendly title of the topic."
+          type: string
+        topic:
+          description: "Same as the title but has all whitespace and grammar removed to allow better filtering and searching against a topic."
+          type: string
+        child_topics:
+          description: "A list of child topics that this topic resource relates to in the taxonomy."
+          type: array
+          items:
+            type: string
   responses:
     InvalidRequestError:
       description: "Failed to process the request due to invalid request."

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -21,6 +21,7 @@ paths:
       - $ref: '#/components/parameters/q'
       - $ref: '#/components/parameters/limit'
       - $ref: '#/components/parameters/offset'
+      - $ref: '#/components/parameters/topics'
       responses:
         200:
           description: "A json list containing search results of datasets which are relevant to the search term"
@@ -82,6 +83,12 @@ components:
         type: integer
         minimum: 0
         default: 0
+    topics:
+      name: topics
+      description: "A comma separated list of a maximum of 10 separate topics to filter the dataset search API against topic fields, topic1, topic2 and topic3. Filtering across the levels is not recommended and will likely result in there being no results being returned."
+      in: query
+      schema:
+        type: string
   schemas:
     Datasets:
       description: "The resulting resource of the completed search against a dimension hierarchy."

--- a/taxonomy/taxonomy.json
+++ b/taxonomy/taxonomy.json
@@ -2,101 +2,101 @@
   "topics": [
     {
       "title": "Economy",
-      "formatted_title": "economy",
+      "filterable_title": "economy",
       "child_topics": [
         {
           "title": "Economic output and productivity",
-          "formatted_title": "economicoutputandproductivity",
+          "filterable_title": "economicoutputandproductivity",
           "child_topics": [
             {
               "title": "Output",
-              "formatted_title": "output"
+              "filterable_title": "output"
             },
             {
               "title": "Productivity measures",
-              "formatted_title": "productivitymeasures"
+              "filterable_title": "productivitymeasures"
             },
             {
               "title": "Public services productivity",
-              "formatted_title": "publicservicesproductivity"
+              "filterable_title": "publicservicesproductivity"
             }
           ]
         },
         {
           "title": "Environmental accounts",
-          "formatted_title": "environmentalaccounts"
+          "filterable_title": "environmentalaccounts"
         },
         {
           "title": "Government, public sector and taxes",
-          "formatted_title": "governmentpublicsectorandtaxes",
+          "filterable_title": "governmentpublicsectorandtaxes",
           "child_topics": [
             {
               "title": "Local government finance",
-              "formatted_title": "localgovernmentfinance"
+              "filterable_title": "localgovernmentfinance"
             },
             {
               "title": "Public sector finance",
-              "formatted_title": "publicsectorfinance"
+              "filterable_title": "publicsectorfinance"
             },
             {
               "title": "Public spending",
-              "formatted_title": "publicspending"
+              "filterable_title": "publicspending"
             },
             {
               "title": "Research and development expenditure",
-              "formatted_title": "researchanddevelopmentexpenditure"
+              "filterable_title": "researchanddevelopmentexpenditure"
             },
             {
               "title": "Taxes and revenue",
-              "formatted_title": "taxesandrevenue"
+              "filterable_title": "taxesandrevenue"
             }
           ]
         },
         {
           "title": "Gross Domestic Product (GDP)",
-          "formatted_title": "grossdomesticproductgdp"
+          "filterable_title": "grossdomesticproductgdp"
         },
         {
           "title": "Gross Value Added (GVA)",
-          "formatted_title": "grossvalueaddedgva"
+          "filterable_title": "grossvalueaddedgva"
         },
         {
           "title": "Inflation and price indices",
-          "formatted_title": "inflationandpriceindices"
+          "filterable_title": "inflationandpriceindices"
         },
         {
           "title": "Investments, pensions and trusts",
-          "formatted_title": "investmentspensionsandtrusts"
+          "filterable_title": "investmentspensionsandtrusts"
         },
         {
           "title": "National accounts",
-          "formatted_title": "nationalaccounts",
+          "filterable_title": "nationalaccounts",
           "child_topics": [
             {
               "title": "Balance of payments",
-              "formatted_title": "balanceofpayments"
+              "filterable_title": "balanceofpayments"
             },
             {
               "title": "Satellite accounts",
-              "formatted_title": "satelliteaccounts"
+              "filterable_title": "satelliteaccounts"
             },
             {
               "title": "Supply and use tables",
-              "formatted_title": "supplyandusetables"
+              "filterable_title": "supplyandusetables"
             },
             {
               "title": "UK sector accounts",
-              "formatted_title": "uksectoraccounts"
+              "filterable_title": "uksectoraccounts"
             }
           ]
         },
         {
           "title": "Regional accounts",
-          "formatted_title": "regionalaccounts",
+          "filterable_title": "regionalaccounts",
           "child_topics": [
             {
               "title": "Gross disposable household income",
-              "formatted_title": "grossdisposablehouseholdincome"
+              "filterable_title": "grossdisposablehouseholdincome"
             }
           ]
         }
@@ -104,57 +104,57 @@
     },
     {
       "title": "Employment and labour market",
-      "formatted_title": "employmentandlabourmarket",
+      "filterable_title": "employmentandlabourmarket",
       "child_topics": [
         {
           "title": "People in work",
-          "formatted_title": "peopleinwork",
+          "filterable_title": "peopleinwork",
           "child_topics": [
             {
               "title": "Earnings and working hours",
-              "formatted_title": "earningsandworkinghours"
+              "filterable_title": "earningsandworkinghours"
             },
             {
               "title": "Employment and employee types",
-              "formatted_title": "employmentandemployeetypes"
+              "filterable_title": "employmentandemployeetypes"
             },
             {
               "title": "Labour productivity",
-              "formatted_title": "labourproductivity"
+              "filterable_title": "labourproductivity"
             },
             {
               "title": "Public sector personnel",
-              "formatted_title": "publicsectorpersonnel"
+              "filterable_title": "publicsectorpersonnel"
             },
             {
               "title": "Workplace disputes and working conditions",
-              "formatted_title": "workplacedisputesandworkingconditions"
+              "filterable_title": "workplacedisputesandworkingconditions"
             },
             {
               "title": "Workplace pensions",
-              "formatted_title": "workplacepensions"
+              "filterable_title": "workplacepensions"
             }
           ]
         },
         {
           "title": "People not in work",
-          "formatted_title": "peoplenotinwork",
+          "filterable_title": "peoplenotinwork",
           "child_topics": [
             {
               "title": "Economic inactivity",
-              "formatted_title": "economicinactivity"
+              "filterable_title": "economicinactivity"
             },
             {
               "title": "Out of work benefits",
-              "formatted_title": "outofworkbenefits"
+              "filterable_title": "outofworkbenefits"
             },
             {
               "title": "Redundancies",
-              "formatted_title": "redundancies"
+              "filterable_title": "redundancies"
             },
             {
               "title": "Unemployment",
-              "formatted_title": "unemployment"
+              "filterable_title": "unemployment"
             }
           ]
         }
@@ -162,57 +162,57 @@
     },
     {
       "title": "Employment and labour market",
-      "formatted_title": "employmentandlabourmarket",
+      "filterable_title": "employmentandlabourmarket",
       "child_topics": [
         {
           "title": "People in work",
-          "formatted_title": "peopleinwork",
+          "filterable_title": "peopleinwork",
           "child_topics": [
             {
               "title": "Earnings and working hours",
-              "formatted_title": "earningsandworkinghours"
+              "filterable_title": "earningsandworkinghours"
             },
             {
               "title": "Employment and employee types",
-              "formatted_title": "employmentandemployeetypes"
+              "filterable_title": "employmentandemployeetypes"
             },
             {
               "title": "Labour productivity",
-              "formatted_title": "labourproductivity"
+              "filterable_title": "labourproductivity"
             },
             {
               "title": "Public sector personnel",
-              "formatted_title": "publicsectorpersonnel"
+              "filterable_title": "publicsectorpersonnel"
             },
             {
               "title": "Workplace disputes and working conditions",
-              "formatted_title": "workplacedisputesandworkingconditions"
+              "filterable_title": "workplacedisputesandworkingconditions"
             },
             {
               "title": "Workplace pensions",
-              "formatted_title": "workplacepensions"
+              "filterable_title": "workplacepensions"
             }
           ]
         },
         {
           "title": "People not in work",
-          "formatted_title": "peoplenotinwork",
+          "filterable_title": "peoplenotinwork",
           "child_topics": [
             {
               "title": "Economic inactivity",
-              "formatted_title": "economicinactivity"
+              "filterable_title": "economicinactivity"
             },
             {
               "title": "Out of work benefits",
-              "formatted_title": "outofworkbenefits"
+              "filterable_title": "outofworkbenefits"
             },
             {
               "title": "Redundancies",
-              "formatted_title": "redundancies"
+              "filterable_title": "redundancies"
             },
             {
               "title": "Unemployment",
-              "formatted_title": "unemployment"
+              "filterable_title": "unemployment"
             }
           ]
         }
@@ -220,101 +220,101 @@
     },
     {
       "title": "Economy",
-      "formatted_title": "economy",
+      "filterable_title": "economy",
       "child_topics": [
         {
           "title": "Economic output and productivity",
-          "formatted_title": "economicoutputandproductivity",
+          "filterable_title": "economicoutputandproductivity",
           "child_topics": [
             {
               "title": "Output",
-              "formatted_title": "output"
+              "filterable_title": "output"
             },
             {
               "title": "Productivity measures",
-              "formatted_title": "productivitymeasures"
+              "filterable_title": "productivitymeasures"
             },
             {
               "title": "Public services productivity",
-              "formatted_title": "publicservicesproductivity"
+              "filterable_title": "publicservicesproductivity"
             }
           ]
         },
         {
           "title": "Environmental accounts",
-          "formatted_title": "environmentalaccounts"
+          "filterable_title": "environmentalaccounts"
         },
         {
           "title": "Government, public sector and taxes",
-          "formatted_title": "governmentpublicsectorandtaxes",
+          "filterable_title": "governmentpublicsectorandtaxes",
           "child_topics": [
             {
               "title": "Local government finance",
-              "formatted_title": "localgovernmentfinance"
+              "filterable_title": "localgovernmentfinance"
             },
             {
               "title": "Public sector finance",
-              "formatted_title": "publicsectorfinance"
+              "filterable_title": "publicsectorfinance"
             },
             {
               "title": "Public spending",
-              "formatted_title": "publicspending"
+              "filterable_title": "publicspending"
             },
             {
               "title": "Research and development expenditure",
-              "formatted_title": "researchanddevelopmentexpenditure"
+              "filterable_title": "researchanddevelopmentexpenditure"
             },
             {
               "title": "Taxes and revenue",
-              "formatted_title": "taxesandrevenue"
+              "filterable_title": "taxesandrevenue"
             }
           ]
         },
         {
           "title": "Gross Domestic Product (GDP)",
-          "formatted_title": "grossdomesticproductgdp"
+          "filterable_title": "grossdomesticproductgdp"
         },
         {
           "title": "Gross Value Added (GVA)",
-          "formatted_title": "grossvalueaddedgva"
+          "filterable_title": "grossvalueaddedgva"
         },
         {
           "title": "Inflation and price indices",
-          "formatted_title": "inflationandpriceindices"
+          "filterable_title": "inflationandpriceindices"
         },
         {
           "title": "Investments, pensions and trusts",
-          "formatted_title": "investmentspensionsandtrusts"
+          "filterable_title": "investmentspensionsandtrusts"
         },
         {
           "title": "National accounts",
-          "formatted_title": "nationalaccounts",
+          "filterable_title": "nationalaccounts",
           "child_topics": [
             {
               "title": "Balance of payments",
-              "formatted_title": "balanceofpayments"
+              "filterable_title": "balanceofpayments"
             },
             {
               "title": "Satellite accounts",
-              "formatted_title": "satelliteaccounts"
+              "filterable_title": "satelliteaccounts"
             },
             {
               "title": "Supply and use tables",
-              "formatted_title": "supplyandusetables"
+              "filterable_title": "supplyandusetables"
             },
             {
               "title": "UK sector accounts",
-              "formatted_title": "uksectoraccounts"
+              "filterable_title": "uksectoraccounts"
             }
           ]
         },
         {
           "title": "Regional accounts",
-          "formatted_title": "regionalaccounts",
+          "filterable_title": "regionalaccounts",
           "child_topics": [
             {
               "title": "Gross disposable household income",
-              "formatted_title": "grossdisposablehouseholdincome"
+              "filterable_title": "grossdisposablehouseholdincome"
             }
           ]
         }
@@ -322,221 +322,221 @@
     },
     {
       "title": "People, population and community",
-      "formatted_title": "peoplepopulationandcommunity",
+      "filterable_title": "peoplepopulationandcommunity",
       "child_topics": [
         {
           "title": "Births, deaths and marriages",
-          "formatted_title": "birthsdeathsandmarriages",
+          "filterable_title": "birthsdeathsandmarriages",
           "child_topics": [
             {
               "title": "Adoption",
-              "formatted_title": "adoption"
+              "filterable_title": "adoption"
             },
             {
               "title": "Ageing",
-              "formatted_title": "ageing"
+              "filterable_title": "ageing"
             },
             {
               "title": "Conception and fertility rates",
-              "formatted_title": "conceptionandfertilityrates"
+              "filterable_title": "conceptionandfertilityrates"
             },
             {
               "title": "Deaths",
-              "formatted_title": "deaths"
+              "filterable_title": "deaths"
             },
             {
               "title": "Divorce",
-              "formatted_title": "divorce"
+              "filterable_title": "divorce"
             },
             {
               "title": "Families",
-              "formatted_title": "families"
+              "filterable_title": "families"
             },
             {
               "title": "Life expectancies",
-              "formatted_title": "lifeexpectancies"
+              "filterable_title": "lifeexpectancies"
             },
             {
               "title": "Live births",
-              "formatted_title": "livebirths"
+              "filterable_title": "livebirths"
             },
             {
               "title": "Marriage, cohabitation and civil partnerships",
-              "formatted_title": "marriagecohabitationandcivilpartnerships"
+              "filterable_title": "marriagecohabitationandcivilpartnerships"
             },
             {
               "title": "Maternities",
-              "formatted_title": "maternities"
+              "filterable_title": "maternities"
             },
             {
               "title": "Stillbirths",
-              "formatted_title": "stillbirths"
+              "filterable_title": "stillbirths"
             }
           ]
         },
         {
           "title": "Crime and justice",
-          "formatted_title": "crimeandjustice"
+          "filterable_title": "crimeandjustice"
         },
         {
           "title": "Cultural identity",
-          "formatted_title": "culturalidentity",
+          "filterable_title": "culturalidentity",
           "child_topics": [
             {
               "title": "Ethnicity",
-              "formatted_title": "ethnicity"
+              "filterable_title": "ethnicity"
             },
             {
               "title": "Language",
-              "formatted_title": "language"
+              "filterable_title": "language"
             },
             {
               "title": "Religion",
-              "formatted_title": "religion"
+              "filterable_title": "religion"
             },
             {
               "title": "Sexual identity",
-              "formatted_title": "sexuality"
+              "filterable_title": "sexuality"
             }
           ]
         },
         {
           "title": "Education and childcare",
-          "formatted_title": "educationandchildcare"
+          "filterable_title": "educationandchildcare"
         },
         {
           "title": "Elections",
-          "formatted_title": "elections",
+          "filterable_title": "elections",
           "child_topics": [
             {
               "title": "Electoral registration",
-              "formatted_title": "electoralregistration"
+              "filterable_title": "electoralregistration"
             },
             {
               "title": "General elections",
-              "formatted_title": "generalelections"
+              "filterable_title": "generalelections"
             },
             {
               "title": "Local government elections",
-              "formatted_title": "localgovernmentelections"
+              "filterable_title": "localgovernmentelections"
             }
           ]
         },
         {
           "title": "Health and social care",
-          "formatted_title": "healthandsocialcare",
+          "filterable_title": "healthandsocialcare",
           "child_topics": [
             {
               "title": "Causes of death",
-              "formatted_title": "causesofdeath"
+              "filterable_title": "causesofdeath"
             },
             {
               "title": "Child health",
-              "formatted_title": "childhealth"
+              "filterable_title": "childhealth"
             },
             {
               "title": "Coronavirus (COVID-19)",
-              "formatted_title": "conditionsanddiseases"
+              "filterable_title": "conditionsanddiseases"
             },
             {
               "title": "Disability",
-              "formatted_title": "disability"
+              "filterable_title": "disability"
             },
             {
               "title": "Drug use, alcohol and smoking",
-              "formatted_title": "drugusealcoholandsmoking"
+              "filterable_title": "drugusealcoholandsmoking"
             },
             {
               "title": "Health care system",
-              "formatted_title": "healthcaresystem"
+              "filterable_title": "healthcaresystem"
             },
             {
               "title": "Health inequalities",
-              "formatted_title": "healthinequalities"
+              "filterable_title": "healthinequalities"
             },
             {
               "title": "Health and life expectancies",
-              "formatted_title": "healthandlifeexpectancies"
+              "filterable_title": "healthandlifeexpectancies"
             },
             {
               "title": "Health and well-being",
-              "formatted_title": "healthandwellbeing"
+              "filterable_title": "healthandwellbeing"
             },
             {
               "title": "Mental health",
-              "formatted_title": "mentalhealth"
+              "filterable_title": "mentalhealth"
             },
             {
               "title": "Social care",
-              "formatted_title": "socialcare"
+              "filterable_title": "socialcare"
             }
           ]
         },
         {
           "title": "Household characteristics",
-          "formatted_title": "householdcharacteristics",
+          "filterable_title": "householdcharacteristics",
           "child_topics": [
             {
               "title": "Home internet and social media usage",
-              "formatted_title": "homeinternetandsocialmediausage"
+              "filterable_title": "homeinternetandsocialmediausage"
             }
           ]
         },
         {
           "title": "Housing",
-          "formatted_title": "housing"
+          "filterable_title": "housing"
         },
         {
           "title": "Leisure and tourism",
-          "formatted_title": "leisureandtourism"
+          "filterable_title": "leisureandtourism"
         },
         {
           "title": "Personal and household finances",
-          "formatted_title": "personalandhouseholdfinances",
+          "filterable_title": "personalandhouseholdfinances",
           "child_topics": [
             {
               "title": "Debt",
-              "formatted_title": "debt"
+              "filterable_title": "debt"
             },
             {
               "title": "Expenditure",
-              "formatted_title": "expenditure"
+              "filterable_title": "expenditure"
             },
             {
               "title": "Income and wealth",
-              "formatted_title": "incomeandwealth"
+              "filterable_title": "incomeandwealth"
             },
             {
               "title": "Pensions, savings and investments",
-              "formatted_title": "pensionssavingsandinvestments"
+              "filterable_title": "pensionssavingsandinvestments"
             }
           ]
         },
         {
           "title": "Population and migration",
-          "formatted_title": "populationandmigration",
+          "filterable_title": "populationandmigration",
           "child_topics": [
             {
               "title": "International migration",
-              "formatted_title": "internationalmigration"
+              "filterable_title": "internationalmigration"
             },
             {
               "title": "Migration within the UK",
-              "formatted_title": "migrationwithintheuk"
+              "filterable_title": "migrationwithintheuk"
             },
             {
               "title": "Population estimates",
-              "formatted_title": "populationestimates"
+              "filterable_title": "populationestimates"
             },
             {
               "title": "Population projections",
-              "formatted_title": "populationprojections"
+              "filterable_title": "populationprojections"
             }
           ]
         },
         {
           "title": "Well-being",
-          "formatted_title": "wellbeing"
+          "filterable_title": "wellbeing"
         }
       ]
     }


### PR DESCRIPTION
### What

See title

Also included two new endpoints to return taxonomy (topic hierarchy) on `/taxonomy` and a `/taxonomy/{topic}` to return individual topics and their respective relations with parent or child topic resources, both can be used as validation of topics allowed for filtering the dataset search endpoint.

### How to review

Check changes make sense and responses match swagger specification

### Who can review

Anyone
