### PR TITLE
Add minimum should match field

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -282,6 +282,7 @@ func buildSearchQuery(term string, topicFilters []models.Filter, limit, offset i
 						},
 					},
 				},
+				MinimumShouldMatch: 1,
 			},
 		},
 		Sort:      listOfScores,

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/ONSdigital/log.go v1.0.0
 	github.com/globalsign/mgo v0.0.0-20181015135952-eeefdecb41b8
 	github.com/gorilla/mux v1.7.4
+	github.com/jteeuwen/go-bindata v3.0.7+incompatible // indirect
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
 	github.com/smartystreets/assertions v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,6 +30,8 @@ github.com/gorilla/mux v1.7.4/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB7
 github.com/gorilla/schema v1.1.0/go.mod h1:kgLaKoK1FELgZqMAVxx/5cbj0kT+57qxUrAlIO2eleU=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e h1:0aewS5NTyxftZHSnFaJmWE5oCCrj4DyEXkAiMa1iZJM=
 github.com/hokaccha/go-prettyjson v0.0.0-20190818114111-108c894c2c0e/go.mod h1:pFlLw2CfqZiIBOx6BuCeRLCrfxBJipTY0nIOF/VbGcI=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible h1:91Uy4d9SYVr1kyTJ15wJsog+esAZZl7JmEfTkwmhJts=
+github.com/jteeuwen/go-bindata v3.0.7+incompatible/go.mod h1:JVvhzYOiGBnFSYRyV00iY8q7/0PThjIYav1p9h5dmKs=
 github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/justinas/alice v1.2.0 h1:+MHSA/vccVCF4Uq37S42jwlkvI2Xzl7zTPCN5BnZNVo=

--- a/models/query.go
+++ b/models/query.go
@@ -28,9 +28,10 @@ type Query struct {
 
 // Bool represents the desirable goals for query
 type Bool struct {
-	Filter []Filter `json:"filter,omitempty"`
-	Must   []Match  `json:"must,omitempty"`
-	Should []Match  `json:"should,omitempty"`
+	Filter             []Filter `json:"filter,omitempty"`
+	Must               []Match  `json:"must,omitempty"`
+	Should             []Match  `json:"should,omitempty"`
+	MinimumShouldMatch int      `json:"minimum_should_match,omitempty"`
 }
 
 // Filter represents the filtering object (can only contain eiter term or terms but not both)


### PR DESCRIPTION
### What

Should query being neglected when filter query is also set. This field tells elastic that the boolean should query should find one match otherwise document wont return in combination with a filter.

### How to review

Check both searching and filtering work separately and together.

### Who can review

Anyone
