### PR TITLE
Add dimension filter to dataset search endpoint

### DIFF
--- a/api/datasets.go
+++ b/api/datasets.go
@@ -34,6 +34,7 @@ func (api *SearchAPI) getDatasets(w http.ResponseWriter, r *http.Request) {
 	q := r.FormValue("q")
 	requestedLimit := r.FormValue("limit")
 	requestedOffset := r.FormValue("offset")
+	dimensions := r.FormValue("dimensions")
 	topics := r.FormValue("topics")
 
 	logData := log.Data{
@@ -41,6 +42,7 @@ func (api *SearchAPI) getDatasets(w http.ResponseWriter, r *http.Request) {
 		"requested_limit":  requestedLimit,
 		"requested_offset": requestedOffset,
 		"topics":           topics,
+		"dimensions":       dimensions,
 	}
 
 	log.Event(ctx, "getDatasets endpoint: incoming request", log.INFO, logData)
@@ -89,6 +91,13 @@ func (api *SearchAPI) getDatasets(w http.ResponseWriter, r *http.Request) {
 	logData["limit"] = page.Limit
 	logData["offset"] = page.Offset
 
+	dimensionFilter, err := models.ValidateDimensions(dimensions)
+	if err != nil {
+		log.Event(ctx, "getDatasets endpoint: validate filter by topics", log.ERROR, log.Error(err), logData)
+		setErrorCode(w, err)
+		return
+	}
+
 	topicFilters, err := models.ValidateTopics(topics)
 	if err != nil {
 		log.Event(ctx, "getDatasets endpoint: validate filter by topics", log.ERROR, log.Error(err), logData)
@@ -99,7 +108,7 @@ func (api *SearchAPI) getDatasets(w http.ResponseWriter, r *http.Request) {
 	log.Event(ctx, "getDatasets endpoint: just before querying search index", log.INFO, logData)
 
 	// build dataset search query
-	query := buildSearchQuery(term, topicFilters, limit, offset)
+	query := buildSearchQuery(term, dimensionFilter, topicFilters, limit, offset)
 
 	response, status, err := api.elasticsearch.QueryDatasetSearch(ctx, api.datasetIndex, query, limit, offset)
 	if err != nil {
@@ -119,19 +128,6 @@ func (api *SearchAPI) getDatasets(w http.ResponseWriter, r *http.Request) {
 
 		doc := result.Source
 		doc.Matches = result.Matches
-
-		// Retrieve inner hit matches
-		if result.InnerHits.Dimensions.Hits.Hits != nil {
-			for _, hit := range result.InnerHits.Dimensions.Hits.Hits {
-				if hit.Matches.DimensionLabel != nil {
-					doc.Matches.DimensionLabel = hit.Matches.DimensionLabel
-				}
-
-				if hit.Matches.DimensionName != nil {
-					doc.Matches.DimensionName = hit.Matches.DimensionName
-				}
-			}
-		}
 
 		searchResults.Items = append(searchResults.Items, doc)
 	}
@@ -177,10 +173,9 @@ func setErrorCode(w http.ResponseWriter, err error) {
 	}
 }
 
-func buildSearchQuery(term string, topicFilters []models.Filter, limit, offset int) interface{} {
+func buildSearchQuery(term string, dimensionFilter *models.Filter, topicFilters []models.Filter, limit, offset int) interface{} {
 	var object models.Object
 	highlight := make(map[string]models.Object)
-	innerHighlight := make(map[string]models.Object)
 
 	highlight["alias"] = object
 	highlight["description"] = object
@@ -188,11 +183,8 @@ func buildSearchQuery(term string, topicFilters []models.Filter, limit, offset i
 	highlight["topic1"] = object
 	highlight["topic2"] = object
 	highlight["topic3"] = object
-	innerHighlight["dimensions.label"] = object
-	innerHighlight["dimensions.name"] = object
-
-	// Nested fields like dimensions in the dataset resource cannot be highlighted by es due to being a nested type
-	// Instead this could be done within the API but result in a performance hit or we store the dimension values in the root document
+	highlight["dimensions.label"] = object
+	highlight["dimensions.name"] = object
 
 	alias := make(map[string]string)
 	description := make(map[string]string)
@@ -253,7 +245,7 @@ func buildSearchQuery(term string, topicFilters []models.Filter, limit, offset i
 			Fields:   highlight,
 		},
 		Query: models.Query{
-			Bool: models.Bool{
+			Bool: &models.Bool{
 				Should: []models.Match{
 					aliasMatch,
 					descriptionMatch,
@@ -263,13 +255,6 @@ func buildSearchQuery(term string, topicFilters []models.Filter, limit, offset i
 					topic3Match,
 					{
 						Nested: &models.Nested{
-							InnerHits: &models.InnerHits{
-								Hightlight: &models.Highlight{
-									Fields:   innerHighlight,
-									PreTags:  []string{"<b><em>"},
-									PostTags: []string{"</em></b>"},
-								},
-							},
 							Path: "dimensions",
 							Query: []models.NestedQuery{
 								{
@@ -291,6 +276,10 @@ func buildSearchQuery(term string, topicFilters []models.Filter, limit, offset i
 
 	if topicFilters != nil {
 		query.Query.Bool.Filter = topicFilters
+	}
+
+	if dimensionFilter != nil && dimensionFilter.Nested != nil {
+		query.Query.Bool.Filter = append(query.Query.Bool.Filter, *dimensionFilter)
 	}
 
 	return query

--- a/apierrors/errors.go
+++ b/apierrors/errors.go
@@ -4,24 +4,26 @@ import "errors"
 
 // A list of error messages for Search API
 var (
-	ErrBadSearchQuery         = errors.New("bad query sent to elasticsearch index")
-	ErrEmptySearchTerm        = errors.New("empty search term")
-	ErrIndexNotFound          = errors.New("search index not found")
-	ErrInternalServer         = errors.New("internal server error")
-	ErrMarshallingQuery       = errors.New("failed to marshal query to bytes for request body to send to elastic")
-	ErrParsingQueryParameters = errors.New("failed to parse query parameters, values must be an integer")
-	ErrTooManyTopicFilters    = errors.New("Too many topic filters, limited to a maximum of 10")
-	ErrTopicNotFound          = errors.New("Topic not found")
-	ErrUnmarshallingJSON      = errors.New("failed to parse json body")
-	ErrUnexpectedStatusCode   = errors.New("unexpected status code from elastic api")
+	ErrBadSearchQuery          = errors.New("bad query sent to elasticsearch index")
+	ErrEmptySearchTerm         = errors.New("empty search term")
+	ErrIndexNotFound           = errors.New("search index not found")
+	ErrInternalServer          = errors.New("internal server error")
+	ErrMarshallingQuery        = errors.New("failed to marshal query to bytes for request body to send to elastic")
+	ErrParsingQueryParameters  = errors.New("failed to parse query parameters, values must be an integer")
+	ErrTooManyDimensionFilters = errors.New("Too many dimension filters, limited to a maximum of 10")
+	ErrTooManyTopicFilters     = errors.New("Too many topic filters, limited to a maximum of 10")
+	ErrTopicNotFound           = errors.New("Topic not found")
+	ErrUnmarshallingJSON       = errors.New("failed to parse json body")
+	ErrUnexpectedStatusCode    = errors.New("unexpected status code from elastic api")
 
 	NotFoundMap = map[error]bool{
 		ErrTopicNotFound: true,
 	}
 
 	BadRequestMap = map[error]bool{
-		ErrEmptySearchTerm:        true,
-		ErrParsingQueryParameters: true,
-		ErrTooManyTopicFilters:    true,
+		ErrEmptySearchTerm:         true,
+		ErrParsingQueryParameters:  true,
+		ErrTooManyDimensionFilters: true,
+		ErrTooManyTopicFilters:     true,
 	}
 )

--- a/models/data.go
+++ b/models/data.go
@@ -10,18 +10,9 @@ type Hits struct {
 }
 
 type HitList struct {
-	Score     float64           `json:"_score"`
-	Source    SearchResult      `json:"_source"`
-	Matches   Matches           `json:"highlight,omitempty"`
-	InnerHits ResponseInnerHits `json:"inner_hits,omitempty"`
-}
-
-type ResponseInnerHits struct {
-	Dimensions Dimensions `json:"dimensions,omitempty"`
-}
-
-type Dimensions struct {
-	Hits DimensionHits `json:"hits,omitempty"`
+	Score   float64      `json:"_score"`
+	Source  SearchResult `json:"_source"`
+	Matches Matches      `json:"highlight,omitempty"`
 }
 
 type DimensionHits struct {

--- a/models/filters.go
+++ b/models/filters.go
@@ -7,13 +7,44 @@ import (
 	errs "github.com/ONSdigital/dp-census-dataset-search-api/apierrors"
 )
 
-const maximumTopicFilters = 10
+const (
+	maximumDimensionFilters, maximumTopicFilters = 10, 10
+	dimensionName                                = "dimensions.name"
+	topic1                                       = "topic1"
+	topic2                                       = "topic2"
+	topic3                                       = "topic3"
+)
 
 // ErrorInvalidTopics - return error
 func ErrorInvalidTopics(topicList []string) error {
 	topics := strings.Join(topicList, ",")
 	err := errors.New("invalid list of topics to filter by: " + topics)
 	return err
+}
+
+// ValidateDimensions checks the values in dimensions are valid for
+// querying elasticsearch API
+func ValidateDimensions(dimensions string) (*Filter, error) {
+	if dimensions == "" {
+		return nil, nil
+	}
+
+	dimensionList := strings.Split(dimensions, ",")
+
+	if len(dimensionList) > maximumDimensionFilters {
+		return nil, errs.ErrTooManyDimensionFilters
+	}
+
+	return &Filter{
+		Nested: &Nested{
+			Path: "dimensions",
+			Query: []NestedQuery{
+				{
+					Terms: map[string][]string{dimensionName: dimensionList},
+				},
+			},
+		},
+	}, nil
 }
 
 // ValidateTopics checks the values in topics are valid
@@ -48,19 +79,19 @@ func ValidateTopics(topics string) ([]Filter, error) {
 	var filters []Filter
 	if len(topic1List) > 0 {
 		filters = append(filters, Filter{
-			Terms: map[string][]string{"topic1": topic1List},
+			Terms: map[string][]string{topic1: topic1List},
 		})
 	}
 
 	if len(topic2List) > 0 {
 		filters = append(filters, Filter{
-			Terms: map[string][]string{"topic2": topic2List},
+			Terms: map[string][]string{topic2: topic2List},
 		})
 	}
 
 	if len(topic3List) > 0 {
 		filters = append(filters, Filter{
-			Terms: map[string][]string{"topic3": topic3List},
+			Terms: map[string][]string{topic3: topic3List},
 		})
 	}
 

--- a/models/filters.go
+++ b/models/filters.go
@@ -24,7 +24,7 @@ func ErrorInvalidTopics(topicList []string) error {
 
 // ValidateDimensions checks the values in dimensions are valid for
 // querying elasticsearch API
-func ValidateDimensions(dimensions string) (*Filter, error) {
+func ValidateDimensions(dimensions string) ([]Filter, error) {
 	if dimensions == "" {
 		return nil, nil
 	}
@@ -35,16 +35,22 @@ func ValidateDimensions(dimensions string) (*Filter, error) {
 		return nil, errs.ErrTooManyDimensionFilters
 	}
 
-	return &Filter{
-		Nested: &Nested{
-			Path: "dimensions",
-			Query: []NestedQuery{
-				{
-					Terms: map[string][]string{dimensionName: dimensionList},
+	var filters []Filter
+	for _, dimension := range dimensionList {
+		filters = append(filters, Filter{
+			Nested: &Nested{
+				Path: "dimensions",
+				Query: []NestedQuery{
+					{
+						Term: map[string]string{
+							dimensionName: dimension},
+					},
 				},
 			},
-		},
-	}, nil
+		})
+	}
+
+	return filters, nil
 }
 
 // ValidateTopics checks the values in topics are valid
@@ -79,19 +85,19 @@ func ValidateTopics(topics string) ([]Filter, error) {
 	var filters []Filter
 	if len(topic1List) > 0 {
 		filters = append(filters, Filter{
-			Terms: map[string][]string{topic1: topic1List},
+			Terms: map[string]interface{}{topic1: topic1List},
 		})
 	}
 
 	if len(topic2List) > 0 {
 		filters = append(filters, Filter{
-			Terms: map[string][]string{topic2: topic2List},
+			Terms: map[string]interface{}{topic2: topic2List},
 		})
 	}
 
 	if len(topic3List) > 0 {
 		filters = append(filters, Filter{
-			Terms: map[string][]string{topic3: topic3List},
+			Terms: map[string]interface{}{topic3: topic3List},
 		})
 	}
 

--- a/models/query.go
+++ b/models/query.go
@@ -23,7 +23,8 @@ type Object struct{}
 
 // Query represents the request query details
 type Query struct {
-	Bool Bool `json:"bool"`
+	Bool   *Bool   `json:"bool,omitempty"`
+	Nested *Nested `json:"nested,omitempty"`
 }
 
 // Bool represents the desirable goals for query
@@ -36,8 +37,9 @@ type Bool struct {
 
 // Filter represents the filtering object (can only contain eiter term or terms but not both)
 type Filter struct {
-	Term  map[string]string   `json:"term,omitempty"`
-	Terms map[string][]string `json:"terms,omitempty"`
+	Term   map[string]string   `json:"term,omitempty"`
+	Terms  map[string][]string `json:"terms,omitempty"`
+	Nested *Nested             `json:"nested,omitempty"`
 }
 
 // Match represents the fields that the term should or must match within query
@@ -48,9 +50,8 @@ type Match struct {
 
 // Nested represents a nested query object
 type Nested struct {
-	InnerHits *InnerHits    `json:"inner_hits,omitempty"`
-	Path      string        `json:"path,omitempty"`
-	Query     []NestedQuery `json:"query,omitempty"`
+	Path  string        `json:"path,omitempty"`
+	Query []NestedQuery `json:"query,omitempty"`
 }
 
 // InnerHits represents metadata contained by nested (or inner objects)
@@ -60,7 +61,8 @@ type InnerHits struct {
 
 // NestedQuery represents ...
 type NestedQuery struct {
-	Term map[string]string `json:"term,omitempty"`
+	Term  map[string]string   `json:"term,omitempty"`
+	Terms map[string][]string `json:"terms,omitempty"`
 }
 
 // Scores represents a list of scoring, e.g. scoring on relevance, but can add in secondary

--- a/models/query.go
+++ b/models/query.go
@@ -23,8 +23,7 @@ type Object struct{}
 
 // Query represents the request query details
 type Query struct {
-	Bool   *Bool   `json:"bool,omitempty"`
-	Nested *Nested `json:"nested,omitempty"`
+	Bool *Bool `json:"bool,omitempty"`
 }
 
 // Bool represents the desirable goals for query
@@ -37,9 +36,9 @@ type Bool struct {
 
 // Filter represents the filtering object (can only contain eiter term or terms but not both)
 type Filter struct {
-	Term   map[string]string   `json:"term,omitempty"`
-	Terms  map[string][]string `json:"terms,omitempty"`
-	Nested *Nested             `json:"nested,omitempty"`
+	Term   map[string]string      `json:"term,omitempty"`
+	Terms  map[string]interface{} `json:"terms,omitempty"`
+	Nested *Nested                `json:"nested,omitempty"`
 }
 
 // Match represents the fields that the term should or must match within query
@@ -54,15 +53,11 @@ type Nested struct {
 	Query []NestedQuery `json:"query,omitempty"`
 }
 
-// InnerHits represents metadata contained by nested (or inner objects)
-type InnerHits struct {
-	Hightlight *Highlight `json:"highlight,omitempty"`
-}
-
 // NestedQuery represents ...
 type NestedQuery struct {
-	Term  map[string]string   `json:"term,omitempty"`
-	Terms map[string][]string `json:"terms,omitempty"`
+	Must  []Match                `json:"must,omitempty"`
+	Term  map[string]string      `json:"term,omitempty"`
+	Terms map[string]interface{} `json:"terms,omitempty"`
 }
 
 // Scores represents a list of scoring, e.g. scoring on relevance, but can add in secondary

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -21,6 +21,7 @@ paths:
       - $ref: '#/components/parameters/q'
       - $ref: '#/components/parameters/limit'
       - $ref: '#/components/parameters/offset'
+      - $ref: '#/components/parameters/dimensions'
       - $ref: '#/components/parameters/topics'
       responses:
         200:
@@ -165,6 +166,12 @@ components:
         type: integer
         minimum: 0
         default: 0
+    dimensions:
+      name: dimensions
+      description: "A comma separated list of a maximum of 10 separate dimensions to filter the dataset search API against dimensions.name field."
+      in: query
+      schema:
+        type: string
     topics:
       name: topics
       description: "A comma separated list of a maximum of 10 separate topics to filter the dataset search API against topic fields, topic1, topic2 and topic3. Filtering across the levels is not recommended and will likely result in there being no results being returned."


### PR DESCRIPTION
### What

Dataset search can be filtered based on dimensions, using "And" query to match all terms passed to dimensions query parameter, so a datasets dimensions must contain all dimensions (instead of or query where 1 would only need to match).

Also return empty array for items object instead of null value

### How to review

Check changes make sense

### Who can review

Anyone
